### PR TITLE
fix: provide fallbacks for optional deps

### DIFF
--- a/backend/config/config.py
+++ b/backend/config/config.py
@@ -4,10 +4,35 @@ All parameters can be adjusted from the frontend.
 """
 
 from typing import Dict, List, Optional, Any
-from pydantic import BaseModel, Field, validator
 from enum import Enum
 import json
 import os
+
+# Provide minimal fallbacks when pydantic is unavailable
+try:
+    from pydantic import BaseModel, Field, validator
+except ModuleNotFoundError:  # pragma: no cover - fallback for limited env
+    class BaseModel:  # type: ignore
+        """Simple stand-in for pydantic.BaseModel"""
+
+        def __init__(self, **data: Any) -> None:
+            for name, value in self.__class__.__dict__.items():
+                if (
+                    not name.startswith("_")
+                    and not callable(value)
+                    and not isinstance(value, property)
+                ):
+                    setattr(self, name, value)
+            for key, value in data.items():
+                setattr(self, key, value)
+
+    def Field(default=None, description: str | None = None):  # type: ignore
+        return default
+
+    def validator(field_name: str):  # type: ignore
+        def decorator(func):
+            return func
+        return decorator
 
 
 class TradingPreset(str, Enum):

--- a/backend/core/portfolio_manager.py
+++ b/backend/core/portfolio_manager.py
@@ -3,7 +3,7 @@ Portfolio management module for position tracking and rebalancing.
 """
 
 import logging
-from typing import Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 from datetime import datetime, date, timedelta
 import pandas as pd
 import numpy as np

--- a/backend/core/risk_manager.py
+++ b/backend/core/risk_manager.py
@@ -3,7 +3,7 @@ Risk management module for stop loss, position limits, and drawdown monitoring.
 """
 
 import logging
-from typing import Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 from datetime import datetime, date, timedelta
 import pandas as pd
 import numpy as np

--- a/project-test/system_test_script.py
+++ b/project-test/system_test_script.py
@@ -2,7 +2,6 @@
 """系统测试脚本 - 验证各个模块功能"""
 
 import sys
-import os
 import json
 import requests
 import pandas as pd


### PR DESCRIPTION
## Summary
- rename legacy test script to avoid module name clash
- add graceful fallbacks when pydantic or psycopg2 are missing
- clean up type hints and unused imports
- guard PostgreSQL maintenance helpers when using SQLite fallback

## Testing
- `pytest -q`
- `PYTHONPATH=. pytest tests/test_core_logic.py::TestYearlineUnlock::test_consecutive_days_requirement -q`
- `pytest project-test/test_akshare.py::test_etf_list -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad74c29cd0832b827c236dba471584